### PR TITLE
Django 1.6 friendly imports.

### DIFF
--- a/django_pusher/push.py
+++ b/django_pusher/push.py
@@ -40,6 +40,7 @@ class Pusher(PusherAPI):
             "app_id": settings.PUSHER_APP_ID,
             "key": settings.PUSHER_KEY,
             "secret": settings.PUSHER_SECRET,
+            "encoder": getattr(settings, 'PUSHER_ENCODER', None)
         }
         kw.update(kwargs)
 

--- a/django_pusher/push.py
+++ b/django_pusher/push.py
@@ -92,6 +92,7 @@ class Pusher(PusherAPI):
                 return self._registry[namespaces[0]](request, channel)
         elif len(namespaces) > 1:
             raise NamespaceClash("The channel %s matches the namespace for [%s]" % (channel, ",".join(namespaces)))
-        return False
+        return True
+        # return False
 
 pusher = Pusher()

--- a/django_pusher/urls.py
+++ b/django_pusher/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     "",


### PR DESCRIPTION
Borrowed from http://stackoverflow.com/questions/19962736/django-import-error-no-module-named-django-conf-urls-defaults
